### PR TITLE
Add hooks for CSP

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -244,6 +244,7 @@ namespace WebAssembly {
     Promise&lt;WebAssemblyInstantiatedSource> instantiate(
         BufferSource bytes, optional object importObject);
 
+
     Promise&lt;Instance> instantiate(
         Module moduleObject, optional object importObject);
 };
@@ -501,6 +502,7 @@ interface Module {
     The <dfn constructor for="Module">Module(bytes)</dfn> constructor, when invoked, performs the follwing steps:
 
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
+    1. Perform [$HostEnsureCanCompileWasmBytes()$]
     1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
     1. If |module| is [=error=], throw a {{CompileError}} exception.
     1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and return the result.
@@ -875,3 +877,16 @@ same class of exception is thrown as for out of memory conditions in JavaScript.
 The particular exception here is implementation-defined in both cases.
 
 Note: ECMAScript doesn't specify any sort of behavior on out-of-memory conditions; implementations have been observed to throw OOMError and to crash. Either is valid here.
+
+<h2>Implementation-defined Operations</h2>
+
+<h3>HostEnsureCanCompileWasmBytes()</h3>
+
+HostEnsureCanCompileWasmBytes is an implementation-defined abstract operation
+that allows host environments to block certain WebAssembly functions which
+compile bytes into WebAssembly code.
+
+An implementation of HostEnsureCanCompileWasmBytes may complete normally or
+abruptly. Any abrupt completions will be propagated to its callers. The default
+implementation of HostEnsureCanCompileWasmBytes is to unconditionally return an
+empty normal completion.

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -244,7 +244,6 @@ namespace WebAssembly {
     Promise&lt;WebAssemblyInstantiatedSource> instantiate(
         BufferSource bytes, optional object importObject);
 
-
     Promise&lt;Instance> instantiate(
         Module moduleObject, optional object importObject);
 };

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -304,6 +304,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
 <div algorithm>
     The <dfn method for="WebAssembly">compile(bytes)</dfn> method, when invoked, performs the following steps:
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
+    1. Perform [$HostEnsureCanCompileWasmBytes(bytes)|HostEnsureCanCompileWasmBytes(stableBytes)$]
     1. Let |promise| be [=a new promise=].
     1. [=Asynchronously compile a WebAssembly module=] from |stableBytes| with |promise|.
     1. Return |promise|.
@@ -410,6 +411,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
 <div algorithm>
   The <dfn method for="WebAssembly">instantiate(bytes, importObject)</dfn> method, when invoked, performs the following steps:
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
+    1. Perform [$HostEnsureCanCompileWasmBytes(bytes)|HostEnsureCanCompileWasmBytes(stableBytes)$]
     1. Let |promiseOfModule| be [=a new promise=].
     1. [=Asynchronously compile a WebAssembly module=] from |stableBytes| with |promiseOfModule|.
     1. [=Instantiate a promise of a module|Instantiate=] |promiseOfModule| with imports |importObject| and return the result.
@@ -502,7 +504,7 @@ interface Module {
     The <dfn constructor for="Module">Module(bytes)</dfn> constructor, when invoked, performs the follwing steps:
 
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
-    1. Perform [$HostEnsureCanCompileWasmBytes()$]
+    1. Perform [$HostEnsureCanCompileWasmBytes(bytes)|HostEnsureCanCompileWasmBytes(stableBytes)$]
     1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
     1. If |module| is [=error=], throw a {{CompileError}} exception.
     1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and return the result.
@@ -880,9 +882,9 @@ Note: ECMAScript doesn't specify any sort of behavior on out-of-memory condition
 
 <h2>Implementation-defined Operations</h2>
 
-<h3>HostEnsureCanCompileWasmBytes()</h3>
+<h3 id="host-ensure-can-compile-wasm-bytes">HostEnsureCanCompileWasmBytes(bytes)</h3>
 
-HostEnsureCanCompileWasmBytes is an implementation-defined abstract operation
+<dfn abstract-op>HostEnsureCanCompileWasmBytes(bytes)</dfn> is an implementation-defined abstract operation
 that allows host environments to block certain WebAssembly functions which
 compile bytes into WebAssembly code.
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -112,6 +112,7 @@ Note: This algorithm accepts a {{Response}} object, or a
 
         4. If |response| is not [=CORS-same-origin=], [=reject=] |returnValue| with a {{TypeError}} and abort these substeps.
         1. If |response|'s [=response/status=] is not an [=ok status=], [=reject=] |returnValue| with a {{TypeError}} and abort these substeps.
+        1. Perform [$HostEnsureCanCompileWasmResponse(response)$]
         1. [=Consume body|consume=] |response|'s body as an {{ArrayBuffer}}, and let |bodyPromise| be the result.
 
         Note: Although it is specified here that the response is consumed entirely before compilation proceeds, that is purely for ease of specification; implementations are likely to instead perform processing in a streaming fashion. The different is unobservable, and thus the simpler model is specified. <!-- Using consume is a bit silly as it creates an ArrayBuffer but then we just want the underlying bytes. This is because of how streams is specced in terms of promises and JS objects whereas we want to operate more directly on the underlying concept. We can revisit this if things change in the Streams/Fetch specs. -->
@@ -124,6 +125,17 @@ Note: This algorithm accepts a {{Response}} object, or a
          1. [=Reject=] |returnValue| with |reason|.
      1. Return |returnValue|.
 </div>
+
+<h3 id="host-ensure-can-compile-wasm-response">HostEnsureCanCompileWasmResponse(response)</h3>
+
+<dfn abstract-op>HostEnsureCanCompileWasmResponse(response)</dfn> is an implementation-defined abstract operation
+that allows host environments to block certain WebAssembly functions which
+compile bytes from a Response object into WebAssembly code.
+
+An implementation of HostEnsureCanCompileWasmResponse may complete normally or
+abruptly. Any abrupt completions will be propagated to its callers. The default
+implementation of HostEnsureCanCompileWasmResponse is to unconditionally return an
+empty normal completion.
 
 <h2 id="conventions">Developer-Facing Display Conventions</h2>
 


### PR DESCRIPTION
This PR adds `HostEnsureCanCompileWasmBytes` and `HostEnsureCanCompileWasmResponse` as hooks that allow CSP to enforce its policy, similar to [`HostEnsureCanCompileStrings`](https://tc39.github.io/ecma262/#sec-hostensurecancompilestrings) in the ECMA-262 spec.

Implementations of these abstract operations will be implemented by the CSP spec. See https://github.com/w3c/webappsec-csp/pull/293 for an in-progress PR.